### PR TITLE
Add trust proxy line for auth0 in Heroku

### DIFF
--- a/server.js
+++ b/server.js
@@ -81,7 +81,7 @@ if (app.get("env") === "production") {
   // Uncomment the line below if your application is behind a proxy (like on Heroku)
   // or if you're encountering the error message:
   // "Unable to verify authorization request state"
-  // app.set('trust proxy', 1);
+  app.set("trust proxy", 1);
 }
 
 app.use(session(sess));


### PR DESCRIPTION
Auth0 needs an extra line to work behind the proxy on Heroku. I added the line in the server.js file.